### PR TITLE
RESP-Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# RESP-parser-Fatma-Ebrahim
-a Go library for parsing Redis Serialization Protocol (RESP) data. encodes/decodes various RESP data types, including strings, errors, integers, bulk strings, and arrays.
+# RESP-parser
+This repository contains an implementation of a Go library for parsing Redis Serialization Protocol (RESP) data. encodes/decodes various RESP data types, including strings, errors, integers, bulk strings, and arrays.
+
+## Functions
+
+- `ParseAll(raw string)`: Parses all RESP elements from the raw string.
+- `ParseVerbose(raw string)`: Parses RESP string and return a verbose representation of the parsed elements.
+
+## How to Use:
+### Step 1: Install the library using `go get`
+
+  ```bash
+  go get github.com/codescalersinternships/RESP-parser-Fatma-Ebrahim
+  ```
+
+This command fetches the library and adds it to your project's `go.mod` file.
+
+### Step 2: Import and use the library in your code
+
+  After running `go get`, you can import the library into your project and use the functions as described:
+
+```
+package main
+
+import (
+	"fmt"
+	parser "github.com/codescalersinternships/RESP-parser-Fatma-Ebrahim"
+)
+
+func main() {
+	raw := "*3\r\n$3\r\nset\r\n$6\r\nleader\r\n$7\r\nCharlie\r\n"
+	parsedVerbose, _ := parser.ParseVerbose(raw)
+	fmt.Print(parsedVerbose)
+}
+```

--- a/README.md
+++ b/README.md
@@ -3,8 +3,20 @@ This repository contains an implementation of a Go library for parsing Redis Ser
 
 ## Functions
 
-- `ParseAll(raw string)`: Parses all RESP elements from the raw string.
-- `ParseVerbose(raw string)`: Parses RESP string and return a verbose representation of the parsed elements.
+### `ParseAll(raw string) ([]parsedElement, []byte, error)`
+Parses RESP elements from the raw string and return an array of the parsed elements.
+### `ParseVerbose(raw string) (string, error)` 
+Parses RESP elements and return a verbose string of the parsed elements.
+### `StringToRESPBulkString(s string) (string, error)`
+Encodes a string to a RESP bulk string.
+### `StringToRESPString(s string) (string, error)`
+Encodes a string to a RESP simple string.
+### `ErrorToRESPError(err error) (string, error)`
+Encodes an error to a RESP error.
+### `IntegerToRESPInteger(i int) (string, error)`
+Encodes an integer to a RESP integer.
+### `ArrayToRESPArray(arr []interface{}) (string, error)`
+Encodes an array to a RESP array.
 
 ## How to Use:
 ### Step 1: Install the library using `go get`
@@ -24,12 +36,16 @@ package main
 
 import (
 	"fmt"
-	parser "github.com/codescalersinternships/RESP-parser-Fatma-Ebrahim"
+	parser "github.com/codescalersinternships/RESP-parser-Fatma-Ebrahim/pkg"
 )
 
 func main() {
-	raw := "*3\r\n$3\r\nset\r\n$6\r\nleader\r\n$7\r\nCharlie\r\n"
-	parsedVerbose, _ := parser.ParseVerbose(raw)
+	respBulkString := "$5\r\nhello\r\n"
+	parsedVerbose, _ := parser.ParseVerbose(respBulkString)
 	fmt.Print(parsedVerbose)
+
+    normalString := "hello" 
+	respString:=parser.StringToRESPString(normalString)
+	fmt.Println(respString)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ This repository contains an implementation of a Go library for parsing Redis Ser
 Parses RESP elements from the raw string and return an array of the parsed elements.
 ### `ParseVerbose(raw string) (string, error)` 
 Parses RESP elements and return a verbose string of the parsed elements.
-### `StringToRESPBulkString(s string) (string, error)`
+### `StringToRESPBulkString(s string) string`
 Encodes a string to a RESP bulk string.
-### `StringToRESPString(s string) (string, error)`
+### `StringToRESPString(s string) string`
 Encodes a string to a RESP simple string.
-### `ErrorToRESPError(err error) (string, error)`
+### `ErrorToRESPError(err error) string`
 Encodes an error to a RESP error.
-### `IntegerToRESPInteger(i int) (string, error)`
+### `IntegerToRESPInteger(i int) string`
 Encodes an integer to a RESP integer.
-### `ArrayToRESPArray(arr []interface{}) (string, error)`
+### `ArrayToRESPArray(arr []interface{}) string`
 Encodes an array to a RESP array.
 
 ## How to Use:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	parser "github.com/codescalersinternships/RESP-parser-Fatma-Ebrahim.git/pkg"
 )
 
@@ -15,9 +14,12 @@ func main() {
 	raw := "*3\r\n$3\r\nset\r\n$6\r\nleader\r\n$7\r\nCharlie\r\n"
 	raw += "*4\r\n$3\r\nset\r\n$8\r\nfollower\r\n*2\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n:1000\r\n"	
 
+	raw = "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n"
+	
+
 	parsed, leftover, err := parser.ParseAll(raw)
 	if err != nil {
-		log.Fatalf("Error parsing: %v", err)
+		fmt.Printf("Error parsing: %v\n", err)
 	}
 
 	if len(leftover) != 0 {
@@ -30,7 +32,7 @@ func main() {
 
 	parsedVerbose, err := parser.ParseVerbose(raw)
 	if err != nil {
-		log.Fatalf("Error parsing verbose: %v", err)
+		fmt.Printf("Error parsing verbose: %v\n", err)
 	}
-	fmt.Println(parsedVerbose)
+	fmt.Print(parsedVerbose)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,9 +10,11 @@ func main() {
 
 	// "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n"
 	// "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n:1000\r\n"
+	// ":1000\r\n$7\r\nCharlie\r\n*3\r\n$3\r\nset\r\n$6\r\nleader\r\n$7\r\nCharlie\r\n"
 
 	raw := "*3\r\n$3\r\nset\r\n$6\r\nleader\r\n$7\r\nCharlie\r\n"
-	raw += "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n"	
+	raw += "*4\r\n$3\r\nset\r\n$8\r\nfollower\r\n*2\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n:1000\r\n"	
+
 	parsed, leftover, err := parser.ParseAll(raw)
 	if err != nil {
 		log.Fatalf("Error parsing: %v", err)
@@ -25,4 +27,10 @@ func main() {
 	for i, element := range parsed {
 		fmt.Printf("Element %d: Type: %s, Value: %v, Size: %d\n", i, element.Type, element.Value, element.Size)
 	}
+
+	parsedVerbose, err := parser.ParseVerbose(raw)
+	if err != nil {
+		log.Fatalf("Error parsing verbose: %v", err)
+	}
+	fmt.Println(parsedVerbose)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,12 +9,20 @@ import (
 func main() {
 
 	// "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n"
-	raw := []byte(":-100\r\n")
-	parsed, left, err := parser.ParseAll(raw)
+	// "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n:1000\r\n"
+
+	raw := "*3\r\n$3\r\nset\r\n$6\r\nleader\r\n$7\r\nCharlie\r\n"
+	raw += "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n"	
+	parsed, leftover, err := parser.ParseAll(raw)
 	if err != nil {
 		log.Fatalf("Error parsing: %v", err)
-		return
 	}
-	fmt.Println("parsed:", parsed)
-	fmt.Println("leftover:", len(left))
+
+	if len(leftover) != 0 {
+		fmt.Println("leftover:", len(leftover))
+	}
+
+	for i, element := range parsed {
+		fmt.Printf("Element %d: Type: %s, Value: %v, Size: %d\n", i, element.Type, element.Value, element.Size)
+	}
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	parser "github.com/codescalersinternships/RESP-parser-Fatma-Ebrahim.git/pkg"
+	parser "github.com/codescalersinternships/RESP-parser-Fatma-Ebrahim/pkg"
 )
 
 func main() {
@@ -13,10 +13,8 @@ func main() {
 
 	raw := "*3\r\n$3\r\nset\r\n$6\r\nleader\r\n$7\r\nCharlie\r\n"
 	raw += "*4\r\n$3\r\nset\r\n$8\r\nfollower\r\n*2\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n:1000\r\n"	
-
 	raw = "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n#<t|f>\r\n"
-	
-
+	 
 	parsed, leftover, err := parser.ParseAll(raw)
 	if err != nil {
 		fmt.Printf("Error parsing: %v\n", err)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,7 +13,6 @@ func main() {
 
 	raw := "*3\r\n$3\r\nset\r\n$6\r\nleader\r\n$7\r\nCharlie\r\n"
 	raw += "*4\r\n$3\r\nset\r\n$8\r\nfollower\r\n*2\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n:1000\r\n"	
-	raw = "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n#<t|f>\r\n"
 	 
 	parsed, leftover, err := parser.ParseAll(raw)
 	if err != nil {
@@ -33,4 +32,10 @@ func main() {
 		fmt.Printf("Error parsing verbose: %v\n", err)
 	}
 	fmt.Print(parsedVerbose)
+
+    normalString := "hello" 
+	respString:=parser.StringToRESPString(normalString)
+	fmt.Println(respString)
+	parsedString,_,_ :=parser.ParseAll("$5\r\nhello\r\n")
+	fmt.Println(parsedString[0].Value)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	parser "github.com/codescalersinternships/RESP-parser-Fatma-Ebrahim.git/pkg"
+)
+
+func main() {
+
+	// "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n"
+	raw := []byte(":-100\r\n")
+	parsed, left, err := parser.ParseAll(raw)
+	if err != nil {
+		log.Fatalf("Error parsing: %v", err)
+		return
+	}
+	fmt.Println("parsed:", parsed)
+	fmt.Println("leftover:", len(left))
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,7 +14,7 @@ func main() {
 	raw := "*3\r\n$3\r\nset\r\n$6\r\nleader\r\n$7\r\nCharlie\r\n"
 	raw += "*4\r\n$3\r\nset\r\n$8\r\nfollower\r\n*2\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n:1000\r\n"	
 
-	raw = "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n"
+	raw = "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n#<t|f>\r\n"
 	
 
 	parsed, leftover, err := parser.ParseAll(raw)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/codescalersinternships/RESP-parser-Fatma-Ebrahim.git
+module github.com/codescalersinternships/RESP-parser-Fatma-Ebrahim
 
 go 1.24.6

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/codescalersinternships/RESP-parser-Fatma-Ebrahim.git
+
+go 1.24.6

--- a/pkg/parser.go
+++ b/pkg/parser.go
@@ -27,11 +27,19 @@ type parsedElement struct {
 
 
 func parse_array(raw []byte) (parsedElement, []byte, error) {
-	arraySize, err := strconv.Atoi(string(raw[0]))
+	arraySizeOffset := get_offset(raw)
+	arraySize, err := strconv.Atoi(string(raw[:arraySizeOffset]))
 	if err != nil{
 		return parsedElement{}, raw, err
 	}
-	raw = raw[3:]
+	if arraySize == -1 {
+		return parsedElement{
+			Type:  "array",
+			Value: nil,
+			Size:  arraySize,
+		}, raw[arraySizeOffset+2:], nil
+	}
+	raw = raw[arraySizeOffset+2:]
 	arrayElements := make([]parsedElement, 0)
 	for i := 0; i < arraySize; i++ {
 		parsed, leftover, err := parse_all(raw)
@@ -46,16 +54,26 @@ func parse_array(raw []byte) (parsedElement, []byte, error) {
 		Value: arrayElements,
 		Size:  len(arrayElements),
 	}
+	fmt.Println(parsed)
 	return parsed, raw, nil
 }
 
 func parse_bulk_string(raw []byte) (parsedElement, []byte, error) {
-	bulkSize, err := strconv.Atoi(string(raw[0]))
+	bulkSizeOffset := get_offset(raw)
+	bulkSize, err := strconv.Atoi(string(raw[:bulkSizeOffset]))
 	if err != nil{
 		return parsedElement{}, raw, err
 	}
+	
+	if bulkSize == -1 {
+		return parsedElement{
+			Type:  "bulk",
+			Value: nil,
+			Size:  bulkSize,
+		}, raw[bulkSizeOffset+2:], nil
+	}
 	bulkString := raw[3 : 3+bulkSize]
-	raw = raw[5+bulkSize:]
+	raw = raw[bulkSizeOffset+4+bulkSize:]
 	parsed := parsedElement{
 		Type:  "bulk",
 		Value: string(bulkString),
@@ -120,6 +138,9 @@ func parse_error(raw []byte) (parsedElement, []byte, error) {
 }
 
 func parse_all(raw []byte) (parsedElement, []byte, error) {
+	if len(raw) == 0 {
+		return parsedElement{}, raw, fmt.Errorf("No data to parse")
+	}
 	typeByte := raw[0]
 	raw = raw[1:]
 	switch typeByte {
@@ -155,6 +176,7 @@ func ParseAll(raw string) ([]parsedElement, []byte, error) {
 		parsedElements = append(parsedElements, parsed)
 
 	}
+	// fmt.Println(parsedElements)
 	return parsedElements, leftover, nil
 }
 

--- a/pkg/parser.go
+++ b/pkg/parser.go
@@ -1,0 +1,134 @@
+package resp_parser
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// $bulk string--> $5\r\nhello\r\n
+// *array   -----> *2\r\n $5\r\nhello\r\n $5\r\nworld\r\n
+// +string  -----> +OK\r\n
+// :integer -----> :1000\r\n
+// -error
+
+// raw += "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n"
+// Read Array
+//   #0 BulkString, value: 'set'
+//   #1 BulkString, value: 'leader'
+//   #2 BulkString, value: 'Charlie'
+
+type parsedElement struct {
+	Type  string
+	Value interface{}
+}
+
+func parse_bulk_string(raw []byte) (parsedElement, []byte, error) {
+	fmt.Println("received bulk string", string(raw))
+	bulkSize, err := strconv.Atoi(string(raw[0]))
+	if err != nil{
+		return parsedElement{}, raw, err
+	}
+	bulkString := raw[3 : 3+bulkSize]
+	raw = raw[5+bulkSize:]
+	parsedElement := parsedElement{
+		Type:  "bulk",
+		Value: string(bulkString),
+	}
+	return parsedElement, raw, nil
+
+}
+
+func parse_array(raw []byte) (parsedElement, []byte, error) {
+	fmt.Println("recieved array", string(raw))
+	arraySize, err := strconv.Atoi(string(raw[0]))
+	if err != nil{
+		return parsedElement{}, raw, err
+	}
+	raw = raw[3:]
+	var arrayElements []parsedElement
+	for i := 0; i < arraySize; i++ {
+		parsed, left, err := ParseAll(raw)
+		if err != nil {
+			return parsedElement{}, raw, err
+		}
+		arrayElements = append(arrayElements, parsed)
+		raw = left
+	}
+	parsedElement := parsedElement{
+		Type:  "array",
+		Value: arrayElements,
+	}
+	return parsedElement, raw, nil
+}
+func get_offset(raw []byte) int {
+	for i := 0; i < len(raw); i++ {
+		if raw[i] == '\r' && raw[i+1] == '\n' {
+			return i
+		}
+	}
+	return -1
+}
+
+func parse_string(raw []byte) (parsedElement, []byte, error) {
+	fmt.Println("received string", string(raw))
+	offset := get_offset(raw)
+	if offset == -1 {
+		return parsedElement{}, raw, fmt.Errorf("invalid string")
+	}
+	parsedElement := parsedElement{
+		Type:  "string",
+		Value: string(raw[:offset]),
+	}
+	raw = raw[offset+2:]
+	return parsedElement, raw, nil
+}
+
+func parse_integer(raw []byte) (parsedElement, []byte, error) {
+	fmt.Println("received integer", string(raw))
+	offset := get_offset(raw)
+		if offset == -1 {
+		return parsedElement{}, raw, fmt.Errorf("invalid integer")
+	}
+	value, err := strconv.Atoi(string(raw[:offset]))
+	if err != nil {
+		return parsedElement{}, raw, err
+	}
+	parsedElement := parsedElement{
+		Type:  "integer",
+		Value: value,
+	}
+	raw = raw[offset+2:]
+	return parsedElement, raw, err
+}
+
+func parse_error(raw []byte) (parsedElement, []byte, error) {
+	fmt.Println("received error", string(raw))
+	offset := get_offset(raw)
+	if offset == -1 {
+		return parsedElement{}, raw, fmt.Errorf("invalid error")
+	}
+	parsedElement := parsedElement{
+		Type:  "error",
+		Value: string(raw[:offset]),
+	}
+	fmt.Println("parsed error:", string(raw[:offset]))
+	raw = raw[offset+2:]
+	return parsedElement, raw, nil
+}
+
+func ParseAll(raw []byte) (parsedElement, []byte, error) {
+	typeByte := raw[0]
+	switch typeByte {
+	case '$':
+		return parse_bulk_string(raw[1:])
+	case '*':
+		return parse_array(raw[1:])
+	case '+':
+		return parse_string(raw[1:])
+	case ':':
+		return parse_integer(raw[1:])
+	case '-':
+		return parse_error(raw[1:])
+	}
+	return parsedElement{}, raw, nil
+}

--- a/pkg/parser.go
+++ b/pkg/parser.go
@@ -6,17 +6,13 @@ import (
 	"strings"
 )
 
+// Examples of the supported RESP data types 
 // $bulk string--> $5\r\nhello\r\n
 // *array   -----> *2\r\n $5\r\nhello\r\n $5\r\nworld\r\n
 // +string  -----> +OK\r\n
 // :integer -----> :1000\r\n
-// -error
+// -error   -----> -Error message\r\n
 
-// raw += "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n"
-// Read Array
-//   #0 BulkString, value: 'set'
-//   #1 BulkString, value: 'leader'
-//   #2 BulkString, value: 'Charlie'
 
 type parsedElement struct {
 	Type  string
@@ -24,8 +20,7 @@ type parsedElement struct {
 	Size  int
 }
 
-
-
+// parses_array parses arrays in RESP format
 func parse_array(raw []byte) (parsedElement, []byte, error) {
 	arraySizeOffset := get_offset(raw)
 	arraySize, err := strconv.Atoi(string(raw[:arraySizeOffset]))
@@ -54,10 +49,10 @@ func parse_array(raw []byte) (parsedElement, []byte, error) {
 		Value: arrayElements,
 		Size:  len(arrayElements),
 	}
-	fmt.Println(parsed)
 	return parsed, raw, nil
 }
 
+// parse_bulk_string parses bulk strings in RESP format
 func parse_bulk_string(raw []byte) (parsedElement, []byte, error) {
 	bulkSizeOffset := get_offset(raw)
 	bulkSize, err := strconv.Atoi(string(raw[:bulkSizeOffset]))
@@ -82,15 +77,8 @@ func parse_bulk_string(raw []byte) (parsedElement, []byte, error) {
 	return parsed, raw, nil
 
 }
-func get_offset(raw []byte) int {
-	for i := 0; i < len(raw); i++ {
-		if raw[i] == '\r' && raw[i+1] == '\n' {
-			return i
-		}
-	}
-	return -1
-}
 
+// parse_string parses strings in RESP format
 func parse_string(raw []byte) (parsedElement, []byte, error) {
 	offset := get_offset(raw)
 	if offset == -1 {
@@ -105,6 +93,23 @@ func parse_string(raw []byte) (parsedElement, []byte, error) {
 	return parsed, raw, nil
 }
 
+// parse_error parses errors in RESP format
+func parse_error(raw []byte) (parsedElement, []byte, error) {
+	offset := get_offset(raw)
+	if offset == -1 {
+		return parsedElement{}, raw, fmt.Errorf("invalid error")
+	}
+	parsed := parsedElement{
+		Type:  "error",
+		Value: string(raw[:offset]),
+		Size:  offset,
+	}
+	raw = raw[offset+2:]
+	return parsed, raw, nil
+}
+
+
+// parse_integer parses integers in RESP format
 func parse_integer(raw []byte) (parsedElement, []byte, error) {
 	offset := get_offset(raw)
 		if offset == -1 {
@@ -123,20 +128,18 @@ func parse_integer(raw []byte) (parsedElement, []byte, error) {
 	return parsed, raw, err
 }
 
-func parse_error(raw []byte) (parsedElement, []byte, error) {
-	offset := get_offset(raw)
-	if offset == -1 {
-		return parsedElement{}, raw, fmt.Errorf("invalid error")
+
+// get_offset is a helper function to get the offset of the CRLF sequence of the raw bytes
+func get_offset(raw []byte) int {
+	for i := 0; i < len(raw); i++ {
+		if raw[i] == '\r' && raw[i+1] == '\n' {
+			return i
+		}
 	}
-	parsed := parsedElement{
-		Type:  "error",
-		Value: string(raw[:offset]),
-		Size:  offset,
-	}
-	raw = raw[offset+2:]
-	return parsed, raw, nil
+	return -1
 }
 
+// parse_all parses a single RESP element such as string, integer, bulkstring, array and error of the raw bytes
 func parse_all(raw []byte) (parsedElement, []byte, error) {
 	if len(raw) == 0 {
 		return parsedElement{}, raw, fmt.Errorf("No data to parse")
@@ -155,9 +158,10 @@ func parse_all(raw []byte) (parsedElement, []byte, error) {
 	case '-':
 		return parse_error(raw)
 	}
-	return parsedElement{}, raw, nil
+	return parsedElement{}, raw, fmt.Errorf("Unknown type: %c", typeByte)
 }
 
+// ParseAll parses all RESP elements from the raw string
 func ParseAll(raw string) ([]parsedElement, []byte, error) {
 	rawBytes := []byte(raw)
 	parsed, leftover, err := parse_all(rawBytes)
@@ -176,10 +180,12 @@ func ParseAll(raw string) ([]parsedElement, []byte, error) {
 		parsedElements = append(parsedElements, parsed)
 
 	}
-	// fmt.Println(parsedElements)
 	return parsedElements, leftover, nil
 }
 
+
+
+// ParseVerbose parses RESP string using ParseAll function and return a verbose representation of the parsed elements.
 func ParseVerbose(raw string) (string, error){
 	parsedElements, leftover, err := ParseAll(raw)
 	if err !=nil{
@@ -204,6 +210,7 @@ func ParseVerbose(raw string) (string, error){
 	return result, nil
 }
 
+// parse_array_verbose is a helper function that parses a nested array element and returns a verbose string representation of it.
 func parse_array_verbose(array parsedElement, level int) (string, error) {
 	var result string
 	for i, element := range array.Value.([]parsedElement) {

--- a/pkg/parser.go
+++ b/pkg/parser.go
@@ -20,45 +20,48 @@ import (
 type parsedElement struct {
 	Type  string
 	Value interface{}
+	Size  int
+}
+
+
+
+func parse_array(raw []byte) (parsedElement, []byte, error) {
+	arraySize, err := strconv.Atoi(string(raw[0]))
+	if err != nil{
+		return parsedElement{}, raw, err
+	}
+	raw = raw[3:]
+	arrayElements := make([]parsedElement, 0)
+	for i := 0; i < arraySize; i++ {
+		parsed, leftover, err := parse_all(raw)
+		if err != nil {
+			return parsedElement{}, raw, err
+		}
+		arrayElements = append(arrayElements, parsed)
+		raw = leftover
+	}
+	parsed := parsedElement{
+		Type:  "array",
+		Value: arrayElements,
+		Size:  len(arrayElements),
+	}
+	return parsed, raw, nil
 }
 
 func parse_bulk_string(raw []byte) (parsedElement, []byte, error) {
-	fmt.Println("received bulk string", string(raw))
 	bulkSize, err := strconv.Atoi(string(raw[0]))
 	if err != nil{
 		return parsedElement{}, raw, err
 	}
 	bulkString := raw[3 : 3+bulkSize]
 	raw = raw[5+bulkSize:]
-	parsedElement := parsedElement{
+	parsed := parsedElement{
 		Type:  "bulk",
 		Value: string(bulkString),
+		Size:  bulkSize,
 	}
-	return parsedElement, raw, nil
+	return parsed, raw, nil
 
-}
-
-func parse_array(raw []byte) (parsedElement, []byte, error) {
-	fmt.Println("recieved array", string(raw))
-	arraySize, err := strconv.Atoi(string(raw[0]))
-	if err != nil{
-		return parsedElement{}, raw, err
-	}
-	raw = raw[3:]
-	var arrayElements []parsedElement
-	for i := 0; i < arraySize; i++ {
-		parsed, left, err := ParseAll(raw)
-		if err != nil {
-			return parsedElement{}, raw, err
-		}
-		arrayElements = append(arrayElements, parsed)
-		raw = left
-	}
-	parsedElement := parsedElement{
-		Type:  "array",
-		Value: arrayElements,
-	}
-	return parsedElement, raw, nil
 }
 func get_offset(raw []byte) int {
 	for i := 0; i < len(raw); i++ {
@@ -70,21 +73,20 @@ func get_offset(raw []byte) int {
 }
 
 func parse_string(raw []byte) (parsedElement, []byte, error) {
-	fmt.Println("received string", string(raw))
 	offset := get_offset(raw)
 	if offset == -1 {
 		return parsedElement{}, raw, fmt.Errorf("invalid string")
 	}
-	parsedElement := parsedElement{
+	parsed := parsedElement{
 		Type:  "string",
 		Value: string(raw[:offset]),
+		Size:  offset,
 	}
 	raw = raw[offset+2:]
-	return parsedElement, raw, nil
+	return parsed, raw, nil
 }
 
 func parse_integer(raw []byte) (parsedElement, []byte, error) {
-	fmt.Println("received integer", string(raw))
 	offset := get_offset(raw)
 		if offset == -1 {
 		return parsedElement{}, raw, fmt.Errorf("invalid integer")
@@ -93,42 +95,64 @@ func parse_integer(raw []byte) (parsedElement, []byte, error) {
 	if err != nil {
 		return parsedElement{}, raw, err
 	}
-	parsedElement := parsedElement{
+	parsed := parsedElement{
 		Type:  "integer",
 		Value: value,
+		Size:  offset,
 	}
 	raw = raw[offset+2:]
-	return parsedElement, raw, err
+	return parsed, raw, err
 }
 
 func parse_error(raw []byte) (parsedElement, []byte, error) {
-	fmt.Println("received error", string(raw))
 	offset := get_offset(raw)
 	if offset == -1 {
 		return parsedElement{}, raw, fmt.Errorf("invalid error")
 	}
-	parsedElement := parsedElement{
+	parsed := parsedElement{
 		Type:  "error",
 		Value: string(raw[:offset]),
+		Size:  offset,
 	}
-	fmt.Println("parsed error:", string(raw[:offset]))
 	raw = raw[offset+2:]
-	return parsedElement, raw, nil
+	return parsed, raw, nil
 }
 
-func ParseAll(raw []byte) (parsedElement, []byte, error) {
+func parse_all(raw []byte) (parsedElement, []byte, error) {
 	typeByte := raw[0]
+	raw = raw[1:]
 	switch typeByte {
 	case '$':
-		return parse_bulk_string(raw[1:])
+		return parse_bulk_string(raw)
 	case '*':
-		return parse_array(raw[1:])
+		return parse_array(raw)
 	case '+':
-		return parse_string(raw[1:])
+		return parse_string(raw)
 	case ':':
-		return parse_integer(raw[1:])
+		return parse_integer(raw)
 	case '-':
-		return parse_error(raw[1:])
+		return parse_error(raw)
 	}
 	return parsedElement{}, raw, nil
+}
+
+func ParseAll(raw string) ([]parsedElement, []byte, error) {
+	rawBytes := []byte(raw)
+	parsed, leftover, err := parse_all(rawBytes)
+	if err != nil {
+		return nil, rawBytes, err
+	}
+	
+	parsedElements := make([]parsedElement, 0)
+	parsedElements = append(parsedElements, parsed)
+
+	for len(leftover) != 0 {
+		parsed, leftover, err = parse_all(leftover)
+		if err != nil {
+			return nil, rawBytes, err
+		}
+		parsedElements = append(parsedElements, parsed)
+
+	}
+	return parsedElements, leftover, nil
 }

--- a/pkg/parser.go
+++ b/pkg/parser.go
@@ -108,7 +108,6 @@ func parse_error(raw []byte) (parsedElement, []byte, error) {
 	return parsed, raw, nil
 }
 
-
 // parse_integer parses integers in RESP format
 func parse_integer(raw []byte) (parsedElement, []byte, error) {
 	offset := get_offset(raw)
@@ -128,7 +127,6 @@ func parse_integer(raw []byte) (parsedElement, []byte, error) {
 	return parsed, raw, err
 }
 
-
 // get_offset is a helper function to get the offset of the CRLF sequence of the raw bytes
 func get_offset(raw []byte) int {
 	for i := 0; i < len(raw); i++ {
@@ -139,7 +137,7 @@ func get_offset(raw []byte) int {
 	return -1
 }
 
-// parse_all parses a single RESP element such as string, integer, bulkstring, array and error of the raw bytes
+// parse_all is a parses a single RESP element such as string, integer, bulkstring, array and error of the raw bytes
 func parse_all(raw []byte) (parsedElement, []byte, error) {
 	if len(raw) == 0 {
 		return parsedElement{}, raw, fmt.Errorf("No data to parse")
@@ -183,8 +181,6 @@ func ParseAll(raw string) ([]parsedElement, []byte, error) {
 	return parsedElements, leftover, nil
 }
 
-
-
 // ParseVerbose parses RESP string using ParseAll function and return a verbose representation of the parsed elements.
 func ParseVerbose(raw string) (string, error){
 	parsedElements, leftover, err := ParseAll(raw)
@@ -227,3 +223,52 @@ func parse_array_verbose(array parsedElement, level int) (string, error) {
 	}
 	return result, nil
 }
+
+
+
+// StringToRESPBulkString converts string to RESP bulk string
+func StringToRESPBulkString(s string) string {
+	return fmt.Sprintf("$%d\r\n%s\r\n", len(s), s)
+}
+
+// StringToRESPString converts string to RESP string
+func StringToRESPString(s string) string {
+	return fmt.Sprintf("+%s\r\n", s)
+}
+
+// ErrorToRESPError converts error to RESP error
+func ErrorToRESPError(e error) string {
+	return fmt.Sprintf("-%s\r\n", e.Error())
+}
+
+// IntegerToRESPInteger converts integer to RESP integer
+func IntegerToRESPInteger(i int) string {
+	return fmt.Sprintf(":%d\r\n", i)
+}
+
+// ArrayToRESPArray converts array to RESP array
+func ArrayToRESPArray(arr []interface{}) string {
+	var result string
+	for _, element := range arr {
+		result += encode_all(element)
+	}
+	return fmt.Sprintf("*%d\r\n%s", len(arr), result)
+}
+
+// encode_all encodes a single element such as string, integer, bulkstring, array and error into RESP format.
+func encode_all(element interface{}) string {
+	switch elementType := element.(type) {
+	case string:
+		return StringToRESPString(elementType)
+	case error:
+		return ErrorToRESPError(elementType)
+	case int:
+		return IntegerToRESPInteger(elementType)
+	case []interface{}:
+		return ArrayToRESPArray(elementType)
+	default:
+		return ""
+	}
+}
+
+

--- a/pkg/parser.go
+++ b/pkg/parser.go
@@ -3,6 +3,7 @@ package resp_parser
 import (
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // $bulk string--> $5\r\nhello\r\n
@@ -155,4 +156,45 @@ func ParseAll(raw string) ([]parsedElement, []byte, error) {
 
 	}
 	return parsedElements, leftover, nil
+}
+
+func ParseVerbose(raw string) (string, error){
+	parsedElements, leftover, err := ParseAll(raw)
+	if err !=nil{
+		return "", err
+	}
+	if len(leftover) != 0 {
+		return "", fmt.Errorf("leftover bytes: %d", len(leftover))
+	}
+	var result string
+	for i, element := range parsedElements {
+		if element.Type == "array" {
+			result += fmt.Sprintf("%d Type: %s, Size: %d\n", i, element.Type, element.Size)
+			nested, err := parse_array_verbose(element, 0)
+			if err != nil {
+				return "", err
+			}
+			result += nested
+		}else{
+			result += fmt.Sprintf("%d Type: %s, Value: %v\n", i, element.Type, element.Value)
+		}
+	}
+	return result, nil
+}
+
+func parse_array_verbose(array parsedElement, level int) (string, error) {
+	var result string
+	for i, element := range array.Value.([]parsedElement) {
+		if element.Type == "array" {
+			result += fmt.Sprintf("%s %d Type: %s, Size: %d\n", strings.Repeat("	", level+1),i, element.Type, element.Size)
+			nested, err := parse_array_verbose(element, level+1)
+			if err != nil {
+				return "", err
+			}
+			result += nested
+		}else{
+			result += fmt.Sprintf("%s%d Type: %s, Value: %v\n",strings.Repeat("	 ", level+1), i, element.Type, element.Value)
+		}
+	}
+	return result, nil
 }

--- a/pkg/parser_test.go
+++ b/pkg/parser_test.go
@@ -6,20 +6,93 @@ import (
 
 func TestParseAll(t *testing.T) {
 	t.Run("test array with bulk string elements", func(t *testing.T) {
-		raw := []byte("*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n")
-		parsed, leftover , err:= ParseAll(raw)
+		raw := "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n"
+		parsed, leftover, err := ParseAll(raw)
 		if err != nil {
-			t.Error("Error in ParseAll")
+			t.Errorf("Error in ParseAll: %v", err)
 		}
+
 		if len(leftover) != 0 {
-			t.Error("Error in ParseAll")
+			t.Errorf("Expected 0 leftover bytes got %d", len(leftover))
 		}
-		if parsed.Type != "array" {
-			t.Errorf("Expected array type got %s", parsed.Type)
+
+		if len(parsed) != 1 {
+			t.Errorf("Expected 1 element got %d", len(parsed))
 		}
-		if len(parsed.Value.([]parsedElement)) != 3 {
-			t.Errorf("Expected 3 elements in array got %d", len(parsed.Value.([]parsedElement)))
+
+		parsedElement := parsed[0]
+		if parsedElement.Type != "array" {
+			t.Errorf("Expected array type got %s", parsedElement.Type)
+		}
+		if parsedElement.Size != 3 {
+			t.Errorf("Expected 3 elements in array got %d", parsedElement.Size)
 		}
 	})
 
+	t.Run("test strings", func(t *testing.T) {
+		raw := "+OK\r\n"
+		parsed, leftover, err := ParseAll(raw)
+		if err != nil {
+			t.Errorf("Error in ParseAll:%v", err)
+		}
+		if len(leftover) != 0 {
+			t.Errorf("Expected 0 leftover bytes got %d", len(leftover))
+		}
+		if len(parsed) != 1 {
+			t.Errorf("Expected 1 element got %d", len(parsed))
+		}
+
+		parsedElement := parsed[0]
+		if parsedElement.Type != "string" {
+			t.Errorf("Expected string type got %s", parsedElement.Type)
+		}
+		if parsedElement.Value != "OK" {
+			t.Errorf("Expected string value 'OK' got %s", parsedElement.Value)
+		}
+
+	})
+
+	t.Run("test integers", func(t *testing.T) {
+		raw := ":1000\r\n"
+		parsed, leftover, err := ParseAll(raw)
+		if err != nil {
+			t.Errorf("Error in ParseAll:%v", err)
+		}
+		if len(leftover) != 0 {
+			t.Errorf("Expected 0 leftover bytes got %d", len(leftover))
+		}
+				if len(parsed) != 1 {
+			t.Errorf("Expected 1 element got %d", len(parsed))
+		}
+
+		parsedElement := parsed[0]
+		if parsedElement.Type != "integer" {
+			t.Errorf("Expected integer type got %s", parsedElement.Type)
+		}
+		if parsedElement.Value != 1000 {
+			t.Errorf("Expected integer value 1000 got %d", parsedElement.Value)
+		}
+	})
+
+	t.Run("test negative integers", func(t *testing.T) {
+		raw := ":-100\r\n"
+		parsed, leftover, err := ParseAll(raw)
+		if err != nil {
+			t.Errorf("Error in ParseAll:%v", err)
+		}
+		if len(leftover) != 0 {
+			t.Errorf("Expected 0 leftover bytes got %d", len(leftover))
+		}
+		if len(parsed) != 1 {
+			t.Errorf("Expected 1 element got %d", len(parsed))
+		}
+
+		parsedElement := parsed[0]
+		if parsedElement.Type != "integer" {
+			t.Errorf("Expected integer type got %s", parsedElement.Type)
+		}
+		if parsedElement.Value != -100 {
+			t.Errorf("Expected integer value -100 got %d", parsedElement.Value)
+		}
+	})
 }

--- a/pkg/parser_test.go
+++ b/pkg/parser_test.go
@@ -30,6 +30,31 @@ func TestParseString(t *testing.T) {
 	})
 }
 
+func TestParseError(t *testing.T) {
+	t.Run("test errors", func(t *testing.T) {
+		raw := "-Error message\r\n"
+		parsed, leftover, err := ParseAll(raw)
+		if err != nil {
+			t.Errorf("Error in ParseAll:%v", err)
+		}
+		if len(leftover) != 0 {
+			t.Errorf("Expected 0 leftover bytes got %d", len(leftover))
+		}
+		if len(parsed) != 1 {
+			t.Errorf("Expected 1 element got %d", len(parsed))
+		}
+
+		parsedElement := parsed[0]
+		if parsedElement.Type != "error" {
+			t.Errorf("Expected error type got %s", parsedElement.Type)
+		}
+		if parsedElement.Value != "Error message" {
+			t.Errorf("Expected error value 'Error message' got %s", parsedElement.Value)
+		}
+
+	})
+}
+
 func TestParseInteger(t *testing.T) {
 	t.Run("test integers", func(t *testing.T) {
 		raw := ":1000\r\n"
@@ -77,7 +102,7 @@ func TestParseInteger(t *testing.T) {
 
 }
 
-func TestParseBulkString( t *testing.T) {
+func TestParseBulkString(t *testing.T) {
 	t.Run("test empty bulk string", func(t *testing.T) {
 		raw := "$0\r\n\r\n"
 		parsed, leftover, err := ParseAll(raw)
@@ -125,7 +150,7 @@ func TestParseBulkString( t *testing.T) {
 
 }
 
-func TestParseArray(t *testing.T){
+func TestParseArray(t *testing.T) {
 	t.Run("test empty array ", func(t *testing.T) {
 		raw := "*0\r\n"
 		parsed, leftover, err := ParseAll(raw)
@@ -179,7 +204,7 @@ func TestParseArray(t *testing.T){
 			t.Errorf("Expected null array got %v", parsedElement.Value)
 		}
 	})
-	
+
 }
 
 func TestParseAll(t *testing.T) {
@@ -205,6 +230,30 @@ func TestParseAll(t *testing.T) {
 		if parsedElement.Size != 3 {
 			t.Errorf("Expected 3 elements in array got %d", parsedElement.Size)
 		}
+	})
+
+	t.Run(("test unknown types"), func(t *testing.T) {
+		raw := "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n,1.23\r\n"
+		parsed, _, err := ParseAll(raw)
+		if err.Error() != "Unknown type: ," {
+			t.Errorf("Expected error 'Unknown type: ,' got %v", err)
+		}
+		if len(parsed) != 0 {
+			t.Errorf("Expected 0 parsed elements got %d", len(parsed))
+		}
+
+	})
+
+	t.Run(("test invalid data"), func(t *testing.T) {
+		raw := "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n"
+		parsed, _, err := ParseAll(raw)
+		if err.Error() != "No data to parse" {
+			t.Errorf("Expected error 'No data to parse' got %v", err)
+		}
+		if len(parsed) != 0 {
+			t.Errorf("Expected 0 parsed elements got %d", len(parsed))
+		}
+
 	})
 
 }

--- a/pkg/parser_test.go
+++ b/pkg/parser_test.go
@@ -1,34 +1,11 @@
 package resp_parser
 
 import (
+	"reflect"
 	"testing"
 )
 
-func TestParseAll(t *testing.T) {
-	t.Run("test array with bulk string elements", func(t *testing.T) {
-		raw := "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n"
-		parsed, leftover, err := ParseAll(raw)
-		if err != nil {
-			t.Errorf("Error in ParseAll: %v", err)
-		}
-
-		if len(leftover) != 0 {
-			t.Errorf("Expected 0 leftover bytes got %d", len(leftover))
-		}
-
-		if len(parsed) != 1 {
-			t.Errorf("Expected 1 element got %d", len(parsed))
-		}
-
-		parsedElement := parsed[0]
-		if parsedElement.Type != "array" {
-			t.Errorf("Expected array type got %s", parsedElement.Type)
-		}
-		if parsedElement.Size != 3 {
-			t.Errorf("Expected 3 elements in array got %d", parsedElement.Size)
-		}
-	})
-
+func TestParseString(t *testing.T) {
 	t.Run("test strings", func(t *testing.T) {
 		raw := "+OK\r\n"
 		parsed, leftover, err := ParseAll(raw)
@@ -51,7 +28,9 @@ func TestParseAll(t *testing.T) {
 		}
 
 	})
+}
 
+func TestParseInteger(t *testing.T) {
 	t.Run("test integers", func(t *testing.T) {
 		raw := ":1000\r\n"
 		parsed, leftover, err := ParseAll(raw)
@@ -61,7 +40,7 @@ func TestParseAll(t *testing.T) {
 		if len(leftover) != 0 {
 			t.Errorf("Expected 0 leftover bytes got %d", len(leftover))
 		}
-				if len(parsed) != 1 {
+		if len(parsed) != 1 {
 			t.Errorf("Expected 1 element got %d", len(parsed))
 		}
 
@@ -95,4 +74,137 @@ func TestParseAll(t *testing.T) {
 			t.Errorf("Expected integer value -100 got %d", parsedElement.Value)
 		}
 	})
+
+}
+
+func TestParseBulkString( t *testing.T) {
+	t.Run("test empty bulk string", func(t *testing.T) {
+		raw := "$0\r\n\r\n"
+		parsed, leftover, err := ParseAll(raw)
+		if err != nil {
+			t.Errorf("Error in ParseAll:%v", err)
+		}
+		if len(leftover) != 0 {
+			t.Errorf("Expected 0 leftover bytes got %d", len(leftover))
+		}
+		if len(parsed) != 1 {
+			t.Errorf("Expected 1 element got %d", len(parsed))
+		}
+
+		parsedElement := parsed[0]
+		if parsedElement.Type != "bulk" {
+			t.Errorf("Expected bulk string type got %s", parsedElement.Type)
+		}
+		if parsedElement.Value != "" {
+			t.Errorf("Expected empty bulk string value got %s", parsedElement.Value)
+		}
+
+	})
+
+	t.Run("test null bulk string", func(t *testing.T) {
+		raw := "$-1\r\n"
+		parsed, leftover, err := ParseAll(raw)
+		if err != nil {
+			t.Errorf("Error in ParseAll:%v", err)
+		}
+		if len(leftover) != 0 {
+			t.Errorf("Expected 0 leftover bytes got %d", len(leftover))
+		}
+		if len(parsed) != 1 {
+			t.Errorf("Expected 1 element got %d", len(parsed))
+		}
+
+		parsedElement := parsed[0]
+		if parsedElement.Type != "bulk" {
+			t.Errorf("Expected bulk string type got %s", parsedElement.Type)
+		}
+		if parsedElement.Value != nil {
+			t.Errorf("Expected null bulk string value got %s", parsedElement.Value)
+		}
+	})
+
+}
+
+func TestParseArray(t *testing.T){
+	t.Run("test empty array ", func(t *testing.T) {
+		raw := "*0\r\n"
+		parsed, leftover, err := ParseAll(raw)
+		if err != nil {
+			t.Errorf("Error in ParseAll:%v", err)
+		}
+		if len(leftover) != 0 {
+			t.Errorf("Expected 0 leftover bytes got %d", len(leftover))
+		}
+		if len(parsed) != 1 {
+			t.Errorf("Expected 1 element got %d", len(parsed))
+		}
+
+		parsedElement := parsed[0]
+		if parsedElement.Type != "array" {
+			t.Errorf("Expected array type got %s", parsedElement.Type)
+		}
+
+		if parsedElement.Size != 0 {
+			t.Errorf("Expected 0 array size got %d", parsedElement.Size)
+
+			if !reflect.DeepEqual(parsedElement.Value, []interface{}{}) {
+				t.Errorf("Expected empty array got %v", parsedElement.Value)
+			}
+		}
+	})
+
+	t.Run("test null array ", func(t *testing.T) {
+		raw := "*-1\r\n"
+		parsed, leftover, err := ParseAll(raw)
+		if err != nil {
+			t.Errorf("Error in ParseAll:%v", err)
+		}
+		if len(leftover) != 0 {
+			t.Errorf("Expected 0 leftover bytes got %d", len(leftover))
+		}
+		if len(parsed) != 1 {
+			t.Errorf("Expected 1 element got %d", len(parsed))
+		}
+
+		parsedElement := parsed[0]
+		if parsedElement.Type != "array" {
+			t.Errorf("Expected array type got %s", parsedElement.Type)
+		}
+
+		if parsedElement.Size != -1 {
+			t.Errorf("Expected -1 array size got %d", parsedElement.Size)
+		}
+
+		if parsedElement.Value != nil {
+			t.Errorf("Expected null array got %v", parsedElement.Value)
+		}
+	})
+	
+}
+
+func TestParseAll(t *testing.T) {
+	t.Run("test array with bulk string elements", func(t *testing.T) {
+		raw := "*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n"
+		parsed, leftover, err := ParseAll(raw)
+		if err != nil {
+			t.Errorf("Error in ParseAll: %v", err)
+		}
+
+		if len(leftover) != 0 {
+			t.Errorf("Expected 0 leftover bytes got %d", len(leftover))
+		}
+
+		if len(parsed) != 1 {
+			t.Errorf("Expected 1 element got %d", len(parsed))
+		}
+
+		parsedElement := parsed[0]
+		if parsedElement.Type != "array" {
+			t.Errorf("Expected array type got %s", parsedElement.Type)
+		}
+		if parsedElement.Size != 3 {
+			t.Errorf("Expected 3 elements in array got %d", parsedElement.Size)
+		}
+	})
+
 }

--- a/pkg/parser_test.go
+++ b/pkg/parser_test.go
@@ -1,6 +1,7 @@
 package resp_parser
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -256,4 +257,66 @@ func TestParseAll(t *testing.T) {
 
 	})
 
+}
+
+func TestStringToRESP(t *testing.T) {
+	t.Run("test string to RESP bulk string", func(t *testing.T) {
+		input := "hello"
+		expected := "$5\r\nhello\r\n"
+		got := StringToRESPBulkString(input)
+		if got != expected {
+			t.Errorf("Expected %q got %q", expected, got)
+		}
+	})
+
+	t.Run("test string to RESP string", func(t *testing.T) {
+		input := "hello"
+		expected := "+hello\r\n"
+		got := StringToRESPString(input)
+		if got != expected {
+			t.Errorf("Expected %q got %q", expected, got)
+		}
+	})
+}
+
+func TestIntegerToRESP(t *testing.T) {
+	t.Run("test integer to RESP integer", func(t *testing.T) {
+		input := 123
+		expected := ":123\r\n"
+		got := IntegerToRESPInteger(input)
+		if got != expected {
+			t.Errorf("Expected %q got %q", expected, got)
+		}
+	})
+
+	t.Run("test negative integer to RESP integer", func(t *testing.T) {
+		input := -123
+		expected := ":-123\r\n"
+		got := IntegerToRESPInteger(input)
+		if got != expected {
+			t.Errorf("Expected %q got %q", expected, got)
+		}
+	})
+}
+
+func TestErrorToRESP(t *testing.T) {
+	t.Run("test error to RESP error", func(t *testing.T) {
+		input := fmt.Errorf("Error message")
+		expected := "-Error message\r\n"
+		got := ErrorToRESPError(input)
+		if got != expected {
+			t.Errorf("Expected %q got %q", expected, got)
+		}
+	})
+}
+
+func TestArrayToRESP(t *testing.T){
+	t.Run("test array to RESP array", func(t *testing.T) {
+		input := []interface{}{"item1", "item2", "item3",1 ,2}
+		expected := "*5\r\n+item1\r\n+item2\r\n+item3\r\n:1\r\n:2\r\n"
+		got := ArrayToRESPArray(input)
+		if got != expected {
+			t.Errorf("Expected %q got %q", expected, got)
+		}
+	})
 }

--- a/pkg/parser_test.go
+++ b/pkg/parser_test.go
@@ -1,0 +1,25 @@
+package resp_parser
+
+import (
+	"testing"
+)
+
+func TestParseAll(t *testing.T) {
+	t.Run("test array with bulk string elements", func(t *testing.T) {
+		raw := []byte("*3\r\n$3\r\nset\r\n$8\r\nfollower\r\n$6\r\nSkyler\r\n")
+		parsed, leftover , err:= ParseAll(raw)
+		if err != nil {
+			t.Error("Error in ParseAll")
+		}
+		if len(leftover) != 0 {
+			t.Error("Error in ParseAll")
+		}
+		if parsed.Type != "array" {
+			t.Errorf("Expected array type got %s", parsed.Type)
+		}
+		if len(parsed.Value.([]parsedElement)) != 3 {
+			t.Errorf("Expected 3 elements in array got %d", len(parsed.Value.([]parsedElement)))
+		}
+	})
+
+}


### PR DESCRIPTION
This PR represents the implementation of a Go library for parsing Redis Serialization Protocol (RESP) data. 
It includes the implementation of features such as:

- encoding data types such as strings, errors, integers, bulk strings, and arrays in RESP data.
- decoding RESP data types into normal data types
- verbose parsing function for better readability